### PR TITLE
timeout fix

### DIFF
--- a/ipython_blocking/ipython_magic.py
+++ b/ipython_blocking/ipython_magic.py
@@ -82,7 +82,7 @@ class CaptureMagic(Magics):
             obj.on_click(handler) 
 
         if not getattr(obj, '_has_been_clicked'):
-            return self.capture(lambda: obj._has_been_clicked, replay=False)
+            return self.capture(lambda: obj._has_been_clicked, timeout=args.timeout, replay=False)
             
 
 def load_ipython_extensions():


### PR DESCRIPTION
Fixed a bug where the timeout argument wasn't being passed properly with the blockrun magic.

The timeout functionality is a useful feature to work around the memory leak issues. 