### PR TITLE
Use nbclient utility for ipykernel 6 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The `%block` magic is enabled upon importing `ipython_blocking`.  It takes eithe
 # cell 1
 import ipywidgets as widgets
 import ipython_blocking
-dd = widgets.Dropdown(options=['', 'foo', 'bar', baz'])
+dd = widgets.Dropdown(options=['', 'foo', 'bar', 'baz'])
 dd
 
 # cell 2

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='ipython_blocking',
-      version='0.2.1',
+      version='0.3.0',
       
       author='Matt Kafonek',
       author_email='kafonek@gmail.com',
@@ -12,7 +12,7 @@ setup(name='ipython_blocking',
       long_description_content_type = 'text/markdown',
       
       packages=find_packages(),
-      install_requires=['IPython', 'ipywidgets'],
+      install_requires=['IPython', 'ipywidgets', 'ipykernel>=6', 'nbclient', 'tornado'],
       
       classifiers = ['Framework :: IPython',
                      'Programming Language :: Python',
@@ -20,4 +20,3 @@ setup(name='ipython_blocking',
                      'Development Status :: 3 - Alpha',
                      ],
       license='BSD')
-      


### PR DESCRIPTION
I tried adding async/await throughout the call chain, but that ends up forcing you to await the return value of `%block`, which loses the cleanliness of the magic and forces existing notebooks to be edited.  Maybe there's a cleaner way to do that, but then I stumbled on this utility function in nbclient that does exactly what I wanted.

Some notes:
 * The tornado queue stuff is a workaround for https://github.com/ipython/ipykernel/issues/751
 * Not ideal to pull in nbclient as a dependency just for one function, so maybe it makes sense to re-implement `just_run` -- but in practice I think if you have a recent Jupyter then it will already be there anyway.

Feel free to edit as needed, or reject if there's a better way.

closes #11 
